### PR TITLE
Use sr-only class for header logo site name and add sr nav.

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -296,6 +296,7 @@ module.exports = {
 	variants: {
 		padding: ['responsive', 'first'],
 		margin: ['responsive', 'first'],
+		accessibility: ['responsive', 'focus', 'group-focus']
 	},
 	plugins: []
 };

--- a/templates/_masters/html.twig
+++ b/templates/_masters/html.twig
@@ -25,6 +25,7 @@
 	</head>
 	<body class="min-w-min">
 		{% include "_lib/gtm-body" %}
+		{% include "_masters/sr-nav.twig" %}
 		<div id="site">
 		{% block site %}{% endblock %}
 		</div>

--- a/templates/_masters/sr-nav.twig
+++ b/templates/_masters/sr-nav.twig
@@ -1,2 +1,2 @@
 <a href="#navigation" class="sr-only focus:not-sr-only">Skip to navigation</a>
-<a href="#content" class="sr-only focus:not-sr-only">SKip to content</a>
+<a href="#site" class="sr-only focus:not-sr-only">SKip to content</a>

--- a/templates/_masters/sr-nav.twig
+++ b/templates/_masters/sr-nav.twig
@@ -1,0 +1,2 @@
+<a href="#navigation" class="sr-only focus:not-sr-only">Skip to navigation</a>
+<a href="#content" class="sr-only focus:not-sr-only">SKip to content</a>

--- a/templates/_site/header.twig
+++ b/templates/_site/header.twig
@@ -6,4 +6,6 @@
 			<span class="sr-only">{{ craft.app.systemName }}</span>
 		</a>
 	</div>
+	{# NAV #}
+	<nav id="navigation"></nav>
 </header>

--- a/templates/_site/header.twig
+++ b/templates/_site/header.twig
@@ -1,7 +1,9 @@
 <header>
 	{# LOGO #}
 	<div>
-		<a href="{{ currentSite.getBaseUrl }}">{% include ["_svg/logo-site", "_svg/_undefined"] %}</a>
-		<span class="hidden">{{ craft.app.systemName }}</span>
+		<a href="{{ currentSite.getBaseUrl }}">
+			{% include ["_svg/logo-site", "_svg/_undefined"] %}
+			<span class="sr-only">{{ craft.app.systemName }}</span>
+		</a>
 	</div>
 </header>


### PR DESCRIPTION
It might not be necessary to actually display the site name when the logo link is focused, that can be left to the user of the template to decide. Just in case it IS necessary, I added the 'group-focus' variant for accessibility in the Tailwind config file so it's easier to make the switch.

I also added the hidden nav links to skip to navigation and content. These will be visible when in focus.

