### PR TITLE
Add font filenames array as build variable

### DIFF
--- a/modules/build/src/variables/BuildVariables.php
+++ b/modules/build/src/variables/BuildVariables.php
@@ -60,6 +60,24 @@ class BuildVariable
     {
         return $this->loadJson('/package.json');
     }
+    
+    public function fonts()
+    {
+		$fontsPath = CRAFT_BASE_PATH.'/web/assets/fonts/';
+		$fonts = array();
+		$files = array_diff(scandir($fontsPath), array('.', '..'));;
+
+		forEach ($files as $file)
+		{
+			$font = explode('.', $file)[0];
+
+			if (!in_array($font, $fonts)) {
+				array_push($fonts, $font);
+			}
+		}
+
+		return $fonts;
+	}
 
     public function livereload()
     {

--- a/templates/_masters/fonts.twig
+++ b/templates/_masters/fonts.twig
@@ -1,5 +1,3 @@
-{% set fonts = fonts|default %}
-
-{% for font in fonts %}
+{% for font in craft.build.fonts %}
 	<link rel="preload" href="/assets/fonts/{{ font }}.woff2" as="font" crossorigin />
 {% endfor %}

--- a/templates/_masters/html.twig
+++ b/templates/_masters/html.twig
@@ -17,7 +17,7 @@
 		{% include "_metas/twitter-card" %}
 		{% include "_masters/favicon.twig" %}
 		{% include "_masters/alternates.twig" %}
-		{% include "_masters/fonts.twig" with {fonts: ['TODO']} %}
+		{% include "_masters/fonts.twig" %}
 		{% include "_masters/css.twig" %}
 		{% include "_masters/utils/livereload.twig" %}
 		{% include "_lib/gtm-head" %}


### PR DESCRIPTION
The "fonts" function in BuildVariable.php grabs the filename of every font file found in /web/assest/fonts (avoiding duplicates) and outputs them as the "fonts" build variable. This can be used to automatically generate font preload links in the fonts.twig template, instead of the user having to manually type them. 