### PR TITLE
Add touch screen to tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,16 @@
 'use strict';
+
+const except = (exception, object) => {
+	let output = {};
+
+	Object.keys(object).forEach(key => {
+		if (key !== exception) {
+			output[key] = object[key];
+		}
+	});
+	return output;
+};
+
 module.exports = {
 	purge: [],
 	theme: {
@@ -120,13 +132,13 @@ module.exports = {
 			'3/4': '75%',
 			'1/2': '50%',
 			...theme('spacing'),
-			...theme('screens')
+			...except('touch', theme('screens'))
 		}),
 		minWidth: (theme) => ({
 			none: 'none',
 			full: '100%',
 			...theme('spacing'),
-			...theme('screens')
+			...except('touch', theme('screens'))
 		}),
 		fontFamily: {
 			sans: [
@@ -290,7 +302,10 @@ module.exports = {
 				'-11/12': '-91.666667%',
 				'-9/16': '-56.25%',
 				'-full': '-100%'
-			})
+			}),
+			screens: {
+				'touch': {'raw': '(hover: none)'}
+			}
 		}
 	},
 	variants: {


### PR DESCRIPTION
Allows to override styles and effects based on whether or not the device can hover easily.

**Show element on hover or when is touch (no hover possible):**
```
div class="
   opacity-0 
   hover:opacity-100 
   touch:opacity-100
">
```