### PR TITLE
Add translations structure and use keys instead of english version

### DIFF
--- a/templates/_pages/errors/404.twig
+++ b/templates/_pages/errors/404.twig
@@ -1,8 +1,8 @@
 {% extends "_masters/page.twig" %}
 
-{% set surtitle = "Page Not Found"|t %}
-{% set title = "404. That’s an error."|t %}
-{% set text = "The requested URL {url} was not found on this server."|t(params = {
+{% set surtitle = "error_404_surtitle"|t %}
+{% set title = "error_404_title"|t %}
+{% set text = "error_404_text"|t(params = {
 	url: craft.app.request.absoluteUrl
 }) %}
 

--- a/templates/_pages/errors/offline.twig
+++ b/templates/_pages/errors/offline.twig
@@ -1,7 +1,7 @@
 {% extends "_masters/page.twig" %}
 
-{% set title = "Site Offline"|t %}
-{% set text = "This website is currently offline"|t %}
+{% set title = "error_offline_title"|t %}
+{% set text = "error_offline_text"|t %}
 
 {% block page %}
 	{% include "_layouts/error" %}

--- a/translations/en/site.php
+++ b/translations/en/site.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+	"error_404_surtitle" => "Page Not Found",
+	"error_404_title" => "404. That’s an error.",
+	"error_404_text" => "The requested URL {url} was not found on this server.",
+
+	"error_offline_title" => "Site Offline",
+	"error_offline_text" => "This website is currently offline.",
+
+	"whoops" => "Whoops!",
+	"error_occured" => "An error occured",
+]
+
+?>

--- a/translations/fr/site.php
+++ b/translations/fr/site.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+	"error_404_surtitle" => "Page introuvable",
+	"error_404_title" => "404. C'est une erreur.",
+	"error_404_text" => "L'url demandé {url} est introuvable sur ce serveur.",
+
+	"error_offline_title" => "Site hors-ligne",
+	"error_offline_text" => "Ce site est présentement hors-ligne.",
+
+	"whoops" => "Oups!",
+	"error_occured" => "Une erreur s'est produite.",
+]
+
+?>


### PR DESCRIPTION
Thanks to @fstgerm for the good idea of using keys instead of using the english version text.

**EN file**
`"my_static_message" => "My Static Message"`

**FR file**
`"my_static_message" => "Mon message statique"`

**Twig template**
`{{ "my_static_message"|t }}`
