### PR TITLE
Add hover mq variant

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const screenExceptions = ['touch', '_'];
+const screenExceptions = ['touch', 'mouse'];
 
 const except = (exceptions, object) => {
 	let output = {};
@@ -243,7 +243,7 @@ module.exports = {
 			},
 			screens: {
 				touch: { raw: '(hover: none)' },
-				_: { raw: '(any-hover: hover)' }
+				mouse: { raw: '(any-hover: hover)' }
 			}
 		}
 	},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,12 @@
 'use strict';
 
-const except = (exception, object) => {
+const screenExceptions = ['touch', '_'];
+
+const except = (exceptions, object) => {
 	let output = {};
 
 	Object.keys(object).forEach((key) => {
-		if (key !== exception) {
+		if (!exceptions.includes(key)) {
 			output[key] = object[key];
 		}
 	});
@@ -125,31 +127,31 @@ module.exports = {
 			none: 'none',
 			auto: 'auto',
 			...theme('spacing'),
-			...except('touch', theme('screens'))
+			...except(screenExceptions, theme('screens'))
 		}),
 		minWidth: (theme) => ({
 			none: 'none',
 			auto: 'auto',
 			...theme('spacing'),
-			...except('touch', theme('screens'))
+			...except(screenExceptions, theme('screens'))
 		}),
 		maxHeight: (theme) => ({
 			none: 'none',
 			auto: 'auto',
 			...theme('spacing'),
-			...except('touch', theme('screens'))
+			...except(screenExceptions, theme('screens'))
 		}),
 		minHeight: (theme) => ({
 			none: 'none',
 			auto: 'auto',
 			...theme('spacing'),
-			...except('touch', theme('screens'))
+			...except(screenExceptions, theme('screens'))
 		}),
 		inset: (theme) => ({
 			none: 'none',
 			auto: 'auto',
 			...theme('spacing'),
-			...except('touch', theme('screens'))
+			...except(screenExceptions, theme('screens'))
 		}),
 		fontFamily: {
 			sans: ['Helvetica Neue', 'Arial', 'sans-serif'],
@@ -240,7 +242,8 @@ module.exports = {
 				full: '100%'
 			},
 			screens: {
-				touch: { raw: '(hover: none)' }
+				touch: { raw: '(hover: none)' },
+				_: { raw: '(any-hover: hover)' }
 			}
 		}
 	},


### PR DESCRIPTION
This PR adds a variant that we can use to wrap hover styles in a media query, which outputs:

```css
@media (any-hover: hover) {
    hover\:class-name:hover {
        // ...
    }
}
```

This avoids the "sticking" behavior of hover styles on touch devices. 

I am still unsure about what word or character to use for this though. I decided to use an underscore and use it like `_:hover:class-name`, so it is very succint, but I am open to suggestions.