### PR TITLE
Utilisation favicon.ico en backup

### DIFF
--- a/templates/_master/favicon.twig
+++ b/templates/_master/favicon.twig
@@ -1,1 +1,3 @@
+{# SVG AND ICO MUST BE USED #}
 <link rel="icon" href="/favicon.svg" />
+<link rel="alternate icon" href="/favicon.ico">


### PR DESCRIPTION
Après discussion avec @nitriques , ça prendrait toujours le .ico. En vérifiant un article qui aprlait de L,utilisation du svg, il suggerait d'inclure le ico en abckup de cette manière.