### PR TITLE
Add twig filters and update app.php

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -24,17 +24,15 @@ return [
     'modules' => [
         'build' => \modules\build\Build::class,
         'killswitch' => \modules\killswitch\Killswitch::class,
-        // 'languageRedirect' => [
-        //     'class' => \modules\languageRedirect\LanguageRedirect::class,
-        // ],
-        // 'twigExtension' => [
-        //     'class' => \modules\twigextension\TwigExtension::class,
-        // ]
+        'agency-auth' => \modules\agencyauth\AgencyAuth::class,
+        'language-redirect' => \modules\languageRedirect\LanguageRedirect::class,
+        'twig' => \modules\twig\Twig::class,
     ],
     'bootstrap' => [
         'build',
         'killswitch',
-        // 'languageRedirect',
-        // 'twigExtension'
+        'agency-auth',
+        'twig',
+        'language-redirect',
     ],
 ];

--- a/modules/twig/src/abstracts/Filter.php
+++ b/modules/twig/src/abstracts/Filter.php
@@ -1,0 +1,14 @@
+<?php
+namespace modules\twig\abstracts;
+
+use Craft;
+
+abstract class Filter
+{
+    abstract public function getFilters();
+
+    protected function isDevMode()
+    {
+        return Craft::$app->getConfig()->getGeneral()->devMode;
+    }
+}

--- a/modules/twig/src/filters/Embed.php
+++ b/modules/twig/src/filters/Embed.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace modules\twig\filters;
+
+use modules\twig\abstracts\Filter;
+
+use Craft;
+
+class Embed extends Filter
+{
+    public function getFilters()
+    {
+        return [
+            'youtube' => 'youtube',
+        ];
+    }
+
+    public function youtube($src, $thumbnail = null)
+    {
+        if (empty($src) || strlen($src) > 2083) {
+            if ($this->isDevMode()) {
+                throw new \Exception('Input value is null or is longer than 2032 characters.');
+            }
+            return '';
+        }
+        $reg = '/(?:https?:\/{2}(?:(?:www.youtube(?:-nocookie)?\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=))|(?:youtu\.be\/)))([a-zA-Z0-9_-]{11})/';
+        preg_match($reg, $src, $match);
+        $thumbnailAttr = $thumbnail ? 'style="background-image: url(' . $thumbnail . ');"' : '';
+        if (isset($match[1])) {
+            return '<lite-youtube ' . $thumbnailAttr . 'videoid="' . $match[1] . '" params="modestbranding=1&rel=0&autoplay=1"></lite-youtube>';
+        } elseif ($this->isDevMode()) {
+            throw new \Exception('Not a valid Youtube link.');
+        } else {
+            return '';
+        }
+    }
+}

--- a/modules/twig/src/filters/Image.php
+++ b/modules/twig/src/filters/Image.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace modules\twig\filters;
+
+use modules\twig\abstracts\Filter;
+
+use Craft;
+use craft\elements\Asset;
+
+class Image extends Filter
+{
+    public function getFilters()
+    {
+        return [
+            'img' => 'imgTag',
+            'img_url' => 'imgUrl'
+        ];
+    }
+
+    public function imgUrl($asset, $options = [])
+    {
+        if (empty($asset) || !$asset instanceof Asset) {
+            if ($this->isDevMode()) {
+                throw new \Exception('Input value is null or not a craft\elements\Asset instance.');
+            }
+            return '';
+        }
+
+        $size = !!isset($options['size']) ? $options['size'] : [
+            'width' => 1920,
+            'height' => 0,
+        ];
+
+        $config = Craft::$app->config->getConfigFromFile('general');
+        $url = '';
+
+        if (isset($config['ficelle']) && !empty($config['ficelle'])) {
+            $transform = '';
+
+            if (!empty($size['width'])) {
+                $transform .= '&width=' . $size['width'];
+            }
+
+            if (!empty($size['height'])) {
+                $transform .= '&height=' . $size['height'];
+            }
+
+            $url = 'https://' . $config['ficelle'] . '.ficelle.app/v1?src=' . urlencode($asset->getUrl()) . $transform;
+        } else {
+            $url = $asset->getUrl([
+                'width' => $size['width'] ?? 0,
+                'height' => $size['height'] ?? 0
+            ]);
+        }
+
+        return $url;
+    }
+
+    public function imgTag($asset, $options = [])
+    {
+        if (empty($asset) || !$asset instanceof Asset) {
+            if ($this->isDevMode()) {
+                throw new \Exception('Input value is null or not a craft\elements\Asset instance.');
+            }
+            return '';
+        }
+
+        $images = [
+            [
+                'width' => '400',
+                'height' => '0'
+            ],
+            [
+                'width' => '600',
+                'height' => '0'
+            ],
+            [
+                'width' => '800',
+                'height' => '0'
+            ],
+            [
+                'width' => '1000',
+                'height' => '0'
+            ],
+            [
+                'width' => '1200',
+                'height' => '0'
+            ],
+            [
+                'width' => '1600',
+                'height' => '0'
+            ],
+            [
+                'width' => '1920',
+                'height' => '0'
+            ]
+        ];
+
+        foreach ($images as $index => $image) {
+            $images[$index]['url'] = $this->imgUrl($asset, [
+                'size' => $image,
+            ]);
+        }
+
+        $srcset = implode(', ', array_map(function ($image) {
+            return trim($image['url'] . ' ' . $image['width'] . 'w');
+        }, $images));
+
+        $sizes = !!isset($options['sizes']) ? implode(', ', array_map(function ($size) {
+            $mq = isset($size['mq']) ? $size['mq'] : '';
+            return trim($mq . ' ' . $size['width']);
+        }, $options['sizes'])) : '100vw';
+
+        $attributes = [
+            'srcset' => $srcset,
+            'sizes' => $sizes,
+            'src' => $this->imgUrl($asset),
+            'alt' => $asset->alt,
+        ];
+
+        $attributes = array_merge(isset($options) ? $options : [], $attributes);
+        $computedAttributes = [];
+
+        foreach ($attributes as $key => $value) {
+            $computedAttributes[] = $key . '="' . $value . '"';
+        }
+
+        $computedAttributes = implode(' ', $computedAttributes);
+
+        return '<picture><img ' . $computedAttributes . ' /></picture>';
+    }
+}

--- a/modules/twig/src/filters/Video.php
+++ b/modules/twig/src/filters/Video.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace modules\twig\filters;
+
+use modules\twig\abstracts\Filter;
+
+use Craft;
+use craft\elements\Asset;
+
+class Video extends Filter
+{
+    public function getFilters()
+    {
+        return [
+            'video' => 'videoTag',
+            'video_url' => 'videoUrl'
+        ];
+    }
+
+    public function videoUrl($asset, $options = [])
+    {
+        if (empty($asset) || !$asset instanceof Asset) {
+            if ($this->isDevMode()) {
+                throw new \Exception('Input value is null or not a craft\elements\Asset instance.');
+            }
+            return '';
+        }
+
+        $config = Craft::$app->config->getConfigFromFile('general');
+        $src = $asset->getUrl();
+
+        return $src;
+    }
+
+    public function videoTag($asset, $options = [], $track = [])
+    {
+        if (empty($asset) || !$asset instanceof Asset) {
+            if ($this->isDevMode()) {
+                throw new \Exception('Input value is null or not a craft\elements\Asset instance.');
+            }
+            return '';
+        }
+
+        $src = $this->videoUrl($asset);
+        $type = $asset->mimeType;
+
+        $computedAttributes = [];
+        $computedTrackAttributes = [];
+
+        foreach ($options as $key => $value) {
+            if ($value !== 0 && $value !== 'false' && $value !== false) {
+                $computedAttributes[] = $key . '="' . $value . '"';
+            }
+        }
+        foreach ($track as $key => $value) {
+            $computedTrackAttributes[] = $key . '="' . $value . '"';
+        }
+
+        $computedAttributes = implode(' ', $computedAttributes);
+        $computedTrackAttributes = implode(' ', $computedTrackAttributes);
+
+        return '<video ' . $computedAttributes . '>
+                    <source src="' . $src . '" type="' . $type . '" />
+                    ' . (count($track) > 0 ? '<track ' . $computedTrackAttributes . ' />' : '') . '
+                </video>';
+    }
+}

--- a/modules/twig/src/filters/Video.php
+++ b/modules/twig/src/filters/Video.php
@@ -48,7 +48,7 @@ class Video extends Filter
         $computedTrackAttributes = [];
 
         foreach ($options as $key => $value) {
-            if ($value !== 0 && $value !== 'false' && $value !== false) {
+            if (!empty($value)) {
                 $computedAttributes[] = $key . '="' . $value . '"';
             }
         }

--- a/modules/twig/src/twigextension/TwigExtension.php
+++ b/modules/twig/src/twigextension/TwigExtension.php
@@ -3,118 +3,31 @@
 namespace modules\twig\twigextension;
 
 use Craft;
-use craft\elements\Asset;
 
-use Twig_Extension;
-use Twig_SimpleFilter;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-class TwigExtension extends Twig_Extension
+class TwigExtension extends AbstractExtension
 {
     public function getFilters()
     {
-        return [
-            new Twig_SimpleFilter('img_tag', [$this, 'imgTag']),
-            new Twig_SimpleFilter('img_url', [$this, 'imgUrl']),
-        ];
-    }
+        $filters = [];
 
-    public function imgUrl($asset, $options = [])
-    {
-        if (empty($asset) || !$asset instanceof Asset) {
-            return '';
-        }
+        $filtersFolder = realpath(__DIR__ . '/../filters');
+        $filtersFiles = scandir($filtersFolder);
+        $filtersFiles = array_diff($filtersFiles, array('.', '..'));
 
-        $size = !!isset($options['size']) ? $options['size'] : [
-            'width' => 1920,
-            'height' => 0,
-        ];
+        foreach ($filtersFiles as $file) {
+            $file = current(explode('.', $file));
+            $class = "\\modules\\twig\\filters\\$file";
+            $i = new $class;
+            $classFilters = $i->getFilters();
 
-        $config = Craft::$app->config->getConfigFromFile('general');
-        $url = '';
-
-        if (isset($config['ficelle']) && !empty($config['ficelle'])) {
-            $transform = '';
-
-            if (!empty($size['width'])) {
-                $transform .= '&width=' . $size['width'];
+            foreach ($classFilters as $key => $value) {
+                $filters[] = new TwigFilter($key, [$i, $value]);
             }
-
-            if (!empty($size['height'])) {
-                $transform .= '&height=' . $size['height'];
-            }
-
-            $url = 'https://' . $config['ficelle'] . '.ficelle.app/v1?src=' . urlencode($asset->getUrl()) . $transform;
-        } else {
-            $url = $asset->getUrl([
-                'width' => $size['width'] ?? 0,
-                'height' => $size['height'] ?? 0
-            ]);
         }
 
-        return $url;
-    }
-
-    public function imgTag($asset, $options = [])
-    {
-        if (empty($asset) || !$asset instanceof Asset) {
-            return '';
-        }
-
-        $images = !!isset($options['sizes']) ? $options['sizes'] : [
-            [
-                'width' => '430',
-                'height' => '0',
-                'mq' => '(max-width: 430px)',
-            ],
-            [
-                'width' => '890',
-                'height' => '0',
-                'mq' => '(max-width: 890px)',
-            ],
-            [
-                'width' => '1260',
-                'height' => '0',
-                'mq' => '(max-width: 1260px)',
-            ],
-            [
-                'width' => '1920',
-                'height' => '0',
-                'mq' => '',
-            ],
-        ];
-
-        $urls = [];
-
-        foreach ($images as $index => $image) {
-            $images[$index]['url'] = $this->imgUrl($asset, [
-                'size' => $image,
-            ]);
-        }
-
-        $srcset = implode(', ', array_map(function ($image) {
-            return trim($image['url'] . ' ' . $image['width'] . 'w');
-        }, $images));
-
-        $sizes = implode(', ', array_map(function ($image) {
-            return trim($image['mq'] . ' ' . $image['width'] . 'w');
-        }, $images));
-
-        $attributes = [
-            'srcset' => $srcset,
-            'sizes' => $sizes,
-            'src' => $this->imgUrl($asset),
-            'alt' => $asset->alt,
-        ];
-
-        $attributes = array_merge($attributes, isset($options) ? $options : []);
-        $computedAttributes = [];
-
-        foreach ($attributes as $key => $value) {
-            $computedAttributes[] = $key . '="' . $value . '"';
-        }
-
-        $computedAttributes = implode(' ', $computedAttributes);
-
-        return '<img ' . $computedAttributes . ' />';
+        return $filters;
     }
 }


### PR DESCRIPTION
Modifications to original Image.php:

- `sizes` and `srcset` should work independently of each other. I added a non-modifiable (that could change if needed) `srcset` value with more breakpoints for more granular image size adjustments. I also provided a new default value for sizes of `100vw`. This means that the browser will by default choose the image src with a size that most closely matches the viewport. This can then be modified through the options parameters, ie:

`image|img({sizes:  [{ mq: '(min-width: 760px)', width: '800px' }, { width: '90vw' }]})|raw`

- Wrap the `<img>` tag in a `<picture>` element. I did not think this would be necessary at first, but this fixes multiple Safari quirks and does not affect the layout in any way.